### PR TITLE
Separate leaderboard cfg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- Automatic migration between setting versions
+
+### Improvements
+- Leaderboard configurations are now saved separately (see (issue #7)[https://github.com/kaiusl/KLPlugins.DynLeaderboards/issues/7])
+
+### Fixed
+- Removed non letter or digit characters from leaderboard names to fix possible issues.
+
+
 ## [1.1.1] - 2022-05-03
 
 ### Improvements

--- a/SettingsControl.xaml.cs
+++ b/SettingsControl.xaml.cs
@@ -33,7 +33,6 @@ namespace KLPlugins.DynLeaderboards.Settings {
             this.Plugin = plugin;
 
             if (Settings.DynLeaderboardConfigs.Count == 0) {
-
                 Plugin.AddNewLeaderboard(new DynLeaderboardConfig("Dynamic"));
             }
             CurrentDynLeaderboardSettings = Settings.DynLeaderboardConfigs[0];
@@ -897,21 +896,23 @@ namespace KLPlugins.DynLeaderboards.Settings {
         }
 
         private void AddNewLeaderboard_Button_Click(object sender, RoutedEventArgs e) {
-            var nameNum = Settings.DynLeaderboardConfigs.Count + 1;
-
+            var nameNum = 1;
             while (Settings.DynLeaderboardConfigs.Any(x => x.Name == $"Dynamic{nameNum}")) {
                 nameNum++;
             }
 
-            Settings.DynLeaderboardConfigs.Add(new DynLeaderboardConfig($"Dynamic{nameNum}"));
-            Plugin.AddNewLeaderboard(Settings.DynLeaderboardConfigs.Last());
-            AddSelectDynLeaderboard_ComboBoxItem(Settings.DynLeaderboardConfigs.Last());
+            var cfg = new DynLeaderboardConfig($"Dynamic{nameNum}");
+            AddSelectDynLeaderboard_ComboBoxItem(cfg);
+            Settings.DynLeaderboardConfigs.Add(cfg);
+            Plugin.AddNewLeaderboard(cfg);
             SelectDynLeaderboard_ComboBox.SelectedIndex = SelectDynLeaderboard_ComboBox.Items.Count - 1;
+
         }
 
         private void RemoveLeaderboard_ButtonClick(object sender, RoutedEventArgs e) {
-            if (SelectDynLeaderboard_ComboBox.Items.Count == 1)
+            if (SelectDynLeaderboard_ComboBox.Items.Count == 1) {
                 return;
+            }
 
             int selected = SelectDynLeaderboard_ComboBox.SelectedIndex;
             if (selected == 0) {
@@ -922,10 +923,6 @@ namespace KLPlugins.DynLeaderboards.Settings {
 
             SelectDynLeaderboard_ComboBox.Items.RemoveAt(selected);
             Plugin.RemoveLeaderboardAt(selected);
-            Settings.RemoveLeaderboardAt(selected);
-
-
-            //SelectDynLeaderboard_ComboBox.SelectedIndex = 0;
         }
 
         private void SelectDynLeaderboard_ComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e) {

--- a/SettingsControl.xaml.cs
+++ b/SettingsControl.xaml.cs
@@ -33,8 +33,8 @@ namespace KLPlugins.DynLeaderboards.Settings {
             this.Plugin = plugin;
 
             if (Settings.DynLeaderboardConfigs.Count == 0) {
-                Settings.DynLeaderboardConfigs.Add(new DynLeaderboardConfig($"Dynamic"));
-                Plugin.AddNewLeaderboard(Settings.DynLeaderboardConfigs.Last());
+
+                Plugin.AddNewLeaderboard(new DynLeaderboardConfig("Dynamic"));
             }
             CurrentDynLeaderboardSettings = Settings.DynLeaderboardConfigs[0];
 

--- a/SettingsControl.xaml.cs
+++ b/SettingsControl.xaml.cs
@@ -878,7 +878,13 @@ namespace KLPlugins.DynLeaderboards.Settings {
         }
 
         private void AddNewLeaderboard_Button_Click(object sender, RoutedEventArgs e) {
-            Settings.DynLeaderboardConfigs.Add(new DynLeaderboardConfig($"Dynamic{Settings.DynLeaderboardConfigs.Count + 1}"));
+            var nameNum = Settings.DynLeaderboardConfigs.Count + 1;
+
+            while (Settings.DynLeaderboardConfigs.Any(x => x.Name == $"Dynamic{nameNum}")) {
+                nameNum++;
+            }
+
+            Settings.DynLeaderboardConfigs.Add(new DynLeaderboardConfig($"Dynamic{nameNum}"));
             Plugin.AddNewLeaderboard(Settings.DynLeaderboardConfigs.Last());
             AddSelectDynLeaderboard_ComboBoxItem(Settings.DynLeaderboardConfigs.Last());
             SelectDynLeaderboard_ComboBox.SelectedIndex = SelectDynLeaderboard_ComboBox.Items.Count - 1;
@@ -897,8 +903,10 @@ namespace KLPlugins.DynLeaderboards.Settings {
 
             SelectDynLeaderboard_ComboBox.Items.RemoveAt(selected);
             Plugin.RemoveLeaderboardAt(selected);
-            Settings.DynLeaderboardConfigs.RemoveAt(selected);
-            SelectDynLeaderboard_ComboBox.SelectedIndex = 0;
+            Settings.RemoveLeaderboardAt(selected);
+
+
+            //SelectDynLeaderboard_ComboBox.SelectedIndex = 0;
         }
 
         private void SelectDynLeaderboard_ComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e) {

--- a/SettingsControl.xaml.cs
+++ b/SettingsControl.xaml.cs
@@ -4,6 +4,7 @@ using MahApps.Metro.Controls;
 using SimHub.Plugins.Styles;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
@@ -267,13 +268,26 @@ namespace KLPlugins.DynLeaderboards.Settings {
             var t = new TextBox();
             t.Width = 200;
             t.Text = l.Name;
-            t.TextChanged += (a, b) => {
-                if (Settings.DynLeaderboardConfigs.Any(x => x.Name == t.Text)) {
+            if (l.Name.Contains("CONFLICT")) {
+                t.Background = Brushes.LightPink;
+            }
+
+            t.TextChanged += (sender, b) => {
+                var caretIndex = t.CaretIndex;
+
+                // Remove any nonletter or digit characters
+                char[] arr = t.Text.ToCharArray();
+                var arr2 = Array.FindAll(arr, (c => (char.IsLetterOrDigit(c))));
+                if (arr.Length != arr2.Length) {
+                    t.Text = new string(arr2);
+                    t.CaretIndex = caretIndex - 1;
+                }
+
+                if (Settings.DynLeaderboardConfigs.Count(x => x.Name == t.Text) > 1 || t.Text.Contains("CONFLICT")) {
                     t.Background = Brushes.LightPink;
                     t.ToolTip = "Dynamic leaderboard with same name already exists. Please choose another, if you don't last valid name will be used.";
                 } else {
                     t.Background = Brushes.Transparent;
-                    l.Name = t.Text;
                     t.ToolTip = null;
                     EnablePropertiesDescription_TextBlock.Text = $"Enable/disable properties for currently selected dynamic leaderboard. Each property can be accessed as \"DynLeaderboardsPlugin.{t.Text}.<pos>.<property name>\"";
                     DynLeaderboardPropertyAccess_TextBlock.Text = $"Properties for this dynamic leaderboard are accessible as \"DynLeaderboardsPlugin.{t.Text}.<pos>.<property name>\", for example \"DynLeaderboardsPlugin.{t.Text}.5.Car.Number\"";
@@ -282,6 +296,11 @@ namespace KLPlugins.DynLeaderboards.Settings {
             };
 
             t.LostFocus += (a, b) => {
+                if (t.Background == Brushes.Transparent) {
+                    l.Rename(t.Text);
+                } else {
+                    t.Text = l.Name;
+                }
                 t.Text = l.Name;
                 t.Background = Brushes.Transparent;
                 t.ToolTip = null;

--- a/src/plugin/LeaderboardPlugin.cs
+++ b/src/plugin/LeaderboardPlugin.cs
@@ -73,6 +73,7 @@ namespace KLPlugins.DynLeaderboards {
         /// <param name="pluginManager"></param>
         public void End(PluginManager pluginManager) {
             this.SaveCommonSettings("GeneralSettings", Settings);
+            Settings.SaveDynLeaderboardConfigs();
             if (_values != null) {
                 _values.Dispose();
             }
@@ -111,7 +112,9 @@ namespace KLPlugins.DynLeaderboards {
         /// </summary>
         /// <param name="pluginManager"></param>
         public void Init(PluginManager pluginManager) {
+            PluginSettings.Migrate();
             Settings = this.ReadCommonSettings<PluginSettings>("GeneralSettings", () => new PluginSettings());
+            Settings.ReadDynLeaderboardConfigs();
             LogFileName = $"{Settings.PluginDataLocation}\\Logs\\Log_{PluginStartTime}.txt";
             var gameName = (string)pluginManager.GetPropertyValue<SimHub.Plugins.DataPlugins.DataCore.DataCorePlugin>("CurrentGame");
             Game = new Game(gameName);

--- a/src/plugin/LeaderboardPlugin.cs
+++ b/src/plugin/LeaderboardPlugin.cs
@@ -74,6 +74,15 @@ namespace KLPlugins.DynLeaderboards {
         public void End(PluginManager pluginManager) {
             this.SaveCommonSettings("GeneralSettings", Settings);
             Settings.SaveDynLeaderboardConfigs();
+            // Delete unused files
+            // Say something was acidentally copied there or file and leaderboard names were different which would render original file useless
+            foreach (var fname in Directory.GetFiles(PluginSettings.leaderboardConfigsDataDirName)) {
+                var leaderboardName = fname.Replace(".json", "").Split('\\').Last();
+                if (!Settings.DynLeaderboardConfigs.Any(x => x.Name == leaderboardName)) {
+                    File.Delete(fname);
+                }
+            }
+
             if (_values != null) {
                 _values.Dispose();
             }
@@ -133,8 +142,7 @@ namespace KLPlugins.DynLeaderboards {
 
             GameDataPath = $@"{Settings.PluginDataLocation}\{gameName}";
             if (Settings.DynLeaderboardConfigs.Count == 0) {
-                var s = new DynLeaderboardConfig("Dynamic");
-                Settings.DynLeaderboardConfigs.Add(s);
+                AddNewLeaderboard(new DynLeaderboardConfig("Dynamic"));
             }
             _values = new Values();
             SubscribeToSimHubEvents();
@@ -164,8 +172,11 @@ namespace KLPlugins.DynLeaderboards {
         }
 
         internal void AddNewLeaderboard(DynLeaderboardConfig s) {
-            if (_values != null)
+            if (_values != null) {
+                Settings.DynLeaderboardConfigs.Add(s);
                 _values.AddNewLeaderboard(s);
+                Settings.SaveDynLeaderboardConfigs();
+            }
         }
 
         internal void RemoveLeaderboardAt(int i) {

--- a/src/plugin/LeaderboardPlugin.cs
+++ b/src/plugin/LeaderboardPlugin.cs
@@ -180,6 +180,7 @@ namespace KLPlugins.DynLeaderboards {
         }
 
         internal void RemoveLeaderboardAt(int i) {
+            Settings.RemoveLeaderboardAt(i);
             if (_values != null)
                 _values.LeaderboardValues.RemoveAt(i);
         }

--- a/src/settings/PluginSettings.cs
+++ b/src/settings/PluginSettings.cs
@@ -86,6 +86,8 @@ namespace KLPlugins.DynLeaderboards.Settings {
                 }
             }
 
+            DeleteUnusedFiles();
+
             void RenameOrDeleteOldBackups(DynLeaderboardConfig cfg) {
                 for (int i = 5; i > -1; i--) {
                     var currentBackupName = $"{leaderboardConfigsDataBackupDirName}\\{cfg.Name}_b{i + 1}.json";
@@ -95,6 +97,15 @@ namespace KLPlugins.DynLeaderboards.Settings {
                         } else {
                             File.Delete(currentBackupName);
                         }
+                    }
+                }
+            }
+
+            void DeleteUnusedFiles() {
+                foreach (var fname in Directory.GetFiles(leaderboardConfigsDataDirName)) {
+                    var leaderboardName = fname.Replace(".json", "").Split('\\').Last();
+                    if (!DynLeaderboardConfigs.Any(x => x.Name == leaderboardName)) {
+                        File.Delete(fname);
                     }
                 }
             }

--- a/src/settings/PluginSettings.cs
+++ b/src/settings/PluginSettings.cs
@@ -52,6 +52,15 @@ namespace KLPlugins.DynLeaderboards.Settings {
                     JsonSerializer serializer = new JsonSerializer();
                     var cfg = (DynLeaderboardConfig)serializer.Deserialize(file, typeof(DynLeaderboardConfig));
 
+                    // Check for conflicting leaderboard names. Add CONFLICT to the end of the name.
+                    if (DynLeaderboardConfigs.Any(x => x.Name == cfg.Name)) {
+                        var num = 1;
+                        while (DynLeaderboardConfigs.Any(x => x.Name == $"{cfg.Name}_CONFLICT{num}")) {
+                            num++;
+                        }
+                        cfg.Name = $"{cfg.Name}_CONFLICT{num}";
+                    }
+
                     DynLeaderboardConfigs.Add(cfg);
                 }
             }


### PR DESCRIPTION
Adds #7.

Separated leaderboard configurations from general settings. Added automatic migration to new settings version and backups of leaderboard configurations. 